### PR TITLE
Fix MULTI_PAYMENT balance check (NO_BALANCE validation)

### DIFF
--- a/src/main/java/org/qortal/transaction/MultiPaymentTransaction.java
+++ b/src/main/java/org/qortal/transaction/MultiPaymentTransaction.java
@@ -54,7 +54,7 @@ public class MultiPaymentTransaction extends Transaction {
 		Account sender = getSender();
 
 		// Check sender has enough funds for fee
-		if (sender.getConfirmedBalance(Asset.QORT) > this.multiPaymentTransactionData.getFee())
+		if (sender.getConfirmedBalance(Asset.QORT) < this.multiPaymentTransactionData.getFee())
 			return ValidationResult.NO_BALANCE;
 
 		return new Payment(this.repository).isValid(this.multiPaymentTransactionData.getSenderPublicKey(), payments, this.multiPaymentTransactionData.getFee());


### PR DESCRIPTION
The MULTI_PAYMENT validator currently returns NO_BALANCE when the sender’s confirmed QORT balance is greater than the fee. That comparison is reversed and causes all MULTI_PAYMENT transactions to be rejected even when the sender has sufficient funds.

This PR flips the check to ensure NO_BALANCE is only raised when balance is less than the required fee. This restores expected validation behavior and allows MULTI_PAYMENT transactions to pass when the sender can cover the fee and payment amounts.