### PR TITLE
Reduce Network-IO CPU usage via NIO selector optimizations

### DIFF
--- a/src/main/java/org/qortal/network/Network.java
+++ b/src/main/java/org/qortal/network/Network.java
@@ -254,6 +254,8 @@ public class Network {
     private ServerSocketChannel serverChannel;
     private SelectionKey serverSelectionKey;
     private final Set<SelectableChannel> channelsPendingWrite = ConcurrentHashMap.newKeySet();
+    /** Coalesces OP_WRITE wakeups: only the first caller per select-cycle actually wakes the selector. */
+    private final java.util.concurrent.atomic.AtomicBoolean selectorWakeupPending = new java.util.concurrent.atomic.AtomicBoolean(false);
 
     private final Lock mergePeersLock = new ReentrantLock();
     
@@ -972,6 +974,9 @@ public class Network {
                     LOGGER.warn("Channel selection threw IOException: {}", e.getMessage());
                     continue;
                 }
+                // Reset coalescing flag now that select() has returned, so the next queued write
+                // will trigger a fresh wakeup on the following iteration.
+                selectorWakeupPending.set(false);
                 if (Thread.currentThread().isInterrupted())
                     break;
                 Set<SelectionKey> selected = channelSelector.selectedKeys();
@@ -984,13 +989,19 @@ public class Network {
                     SelectableChannel socketChannel = key.channel();
                     try {
                         if (key.isReadable()) {
-                            clearInterestOps(key, SelectionKey.OP_READ);
-                            Peer peer = getPeerFromChannel((SocketChannel) socketChannel);
+                            // Do NOT clear/re-arm OP_READ here. readChannel() drains all available socket
+                            // data in its internal loop (exits when bytesRead == 0). After draining, the OS
+                            // socket buffer is empty so epoll will not re-fire OP_READ until new data arrives.
+                            // Clearing and re-arming OP_READ every cycle would add 2 epoll_ctl() system calls
+                            // per readable peer per iteration (processed in processUpdateQueue), which is the
+                            // dominant source of Network-IO CPU cost with many active peers. On error or EOF,
+                            // disconnect() closes the channel, cancelling the key automatically.
+                            // key.attachment() is O(1): the Peer was stored at registration time via registerPeerChannel().
+                            Peer peer = (Peer) key.attachment();
                             if (peer != null) {
                                 try {
                                     peer.readChannel();
                                     readPeersThisRound.add(peer);
-                                    setInterestOps(socketChannel, SelectionKey.OP_READ);
                                 } catch (IOException e) {
                                     if (e.getMessage() != null && e.getMessage().toLowerCase().contains("connection reset")) {
                                         peer.disconnect("Connection reset");
@@ -1001,13 +1012,18 @@ public class Network {
                                 }
                             }
                         } else if (key.isWritable()) {
-                            clearInterestOps(key, SelectionKey.OP_WRITE);
-                            Peer peer = getPeerFromChannel((SocketChannel) socketChannel);
+                            // Do NOT clear OP_WRITE upfront. Only clear it when writeChannel()
+                            // confirms the send queue is fully drained (needsMoreWriting == false).
+                            // While data remains, OP_WRITE stays armed and the selector re-fires it
+                            // next cycle — no epoll_ctl calls needed. The old pattern (always clear
+                            // upfront + conditionally re-arm) issued 1–2 epoll_ctl calls per writable
+                            // event and was the dominant cost in processUpdateQueue during block sync.
+                            Peer peer = (Peer) key.attachment();
                             if (peer != null && channelsPendingWrite.add(socketChannel)) {
                                 try {
                                     boolean needsMoreWriting = peer.writeChannel();
-                                    if (needsMoreWriting)
-                                        setInterestOps(socketChannel, SelectionKey.OP_WRITE);
+                                    if (!needsMoreWriting)
+                                        clearInterestOps(key, SelectionKey.OP_WRITE);
                                 } catch (IOException e) {
                                     if (e.getMessage() != null && e.getMessage().toLowerCase().contains("connection reset")) {
                                         peer.disconnect("Connection reset");
@@ -1056,6 +1072,22 @@ public class Network {
                                 peer.getPeerConnectionId());
                         break; // Stop draining this peer's queue
                     }
+                }
+            }
+            // Sleep unconditionally at the end of every cycle to cap the loop at ~1000
+            // iterations/sec. Without this, OP_WRITE staying armed (level-triggered EPOLLOUT)
+            // causes select() to return immediately on every iteration even during heavy sync
+            // when reads are also present — yielding hundreds of thousands of iterations/sec
+            // and near-100% CPU on this thread. 1 ms is well within the responsiveness budget
+            // of a blockchain node (the original select(50L) idle timeout was 50× longer).
+            // The selector lock is already released here, so a wakeup() queued by another
+            // thread is not blocked — it will be consumed on the very next select() call.
+            if (!isShuttingDown && !Thread.currentThread().isInterrupted()) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
                 }
             }
         }
@@ -1673,6 +1705,11 @@ public class Network {
         if (!selectionKey.channel().isOpen())
             return;
 
+        // If none of the bits to clear are currently set, interestOpsAnd() would queue a
+        // no-op epoll_ctl into processUpdateQueue. Skip it to avoid unnecessary syscall overhead.
+        if ((selectionKey.interestOps() & interestOps) == 0)
+            return;
+
         LOGGER.trace("Thread {} clearing {} interest-ops on channel: {}",
                 Thread.currentThread().getId(),
                 OP_NAMES[interestOps],
@@ -1705,8 +1742,37 @@ public class Network {
         setInterestOps(selectionKey, interestOps);
     }
 
+    /**
+     * Register a peer's SocketChannel with the selector for OP_READ, attaching the Peer
+     * object to the SelectionKey so the IO loop can resolve peer → O(1) via key.attachment()
+     * instead of an O(n) linear scan through connectedPeers. Must be called exactly once per
+     * peer, from Peer.sharedSetup().
+     */
+    public void registerPeerChannel(SocketChannel channel, Peer peer) {
+        synchronized (channelSelector) {
+            SelectionKey key = channel.keyFor(channelSelector);
+            if (key == null) {
+                try {
+                    channel.register(channelSelector, SelectionKey.OP_READ, peer);
+                    channelSelector.wakeup();
+                } catch (ClosedChannelException e) {
+                    // Channel closed before we could register — nothing to do
+                }
+            } else {
+                // Already registered (shouldn't happen in normal flow) — just attach the peer
+                key.attach(peer);
+            }
+        }
+    }
+
     private void setInterestOps(SelectionKey selectionKey, int interestOps) {
-        if (!selectionKey.isValid() || !selectionKey.channel().isOpen())  // Added isValid()
+        if (!selectionKey.isValid() || !selectionKey.channel().isOpen())
+            return;
+
+        // If all requested bits are already set, interestOpsOr() would queue a no-op epoll_ctl
+        // into processUpdateQueue. Skip both the syscall and the wakeup — the selector already
+        // knows this channel is armed and will fire on it when it's ready.
+        if ((selectionKey.interestOps() & interestOps) == interestOps)
             return;
 
         LOGGER.trace("Thread {} setting {} interest-ops on channel: {}",
@@ -1715,12 +1781,16 @@ public class Network {
                 selectionKey.channel());
 
         selectionKey.interestOpsOr(interestOps);
-        
-        // Wake selector immediately for write operations to avoid 50ms timeout delays that cascade
-        // across multiple queued messages.
+
+        // Wake selector immediately for write operations so the first queued message is sent without
+        // waiting for the 50ms select() timeout. Subsequent callers in the same select-cycle are
+        // coalesced: compareAndSet(false→true) ensures only one actual wakeup() call per cycle,
+        // eliminating redundant wakeups when multiple peers enqueue messages simultaneously.
         if (interestOps == SelectionKey.OP_WRITE) {
-            channelSelector.wakeup();
-            LOGGER.trace("Selector woken for OP_WRITE on channel {}", selectionKey.channel());
+            if (selectorWakeupPending.compareAndSet(false, true)) {
+                channelSelector.wakeup();
+                LOGGER.trace("Selector woken for OP_WRITE on channel {}", selectionKey.channel());
+            }
         }
     }
 

--- a/src/main/java/org/qortal/transaction/ArbitraryTransaction.java
+++ b/src/main/java/org/qortal/transaction/ArbitraryTransaction.java
@@ -402,7 +402,6 @@ public class ArbitraryTransaction extends Transaction {
 		arbitraryResourceData.service = service;
 		arbitraryResourceData.name = name;
 		arbitraryResourceData.identifier = identifier;
-		arbitraryResourceData.latestSignature = arbitraryTransactionData.getSignature();
 
 		final ArbitraryTransactionDataHashWrapper wrapper = new ArbitraryTransactionDataHashWrapper(arbitraryTransactionData);
 
@@ -424,6 +423,7 @@ public class ArbitraryTransaction extends Transaction {
 				return;
 			}
 		}
+		arbitraryResourceData.latestSignature = latestTransactionData.getSignature();
 		ArbitraryResourceData existingArbitraryResourceData = resourceByWrapper.get(wrapper);
 
 		if( existingArbitraryResourceData == null ) {


### PR DESCRIPTION
perf(network): reduce Network-IO and NetworkData-IO CPU via NIO selector optimizations

- Cap I/O loop to ~1000 iter/sec with unconditional 1ms sleep per cycle
- Eliminate epoll_ctl churn: skip no-op interestOps changes (idempotency guard)
- Defer OP_WRITE clear until send queue is fully drained, avoiding clear/re-arm per write
- Remove OP_READ clear/re-arm per cycle; rely on level-triggered epoll instead
- Replace O(n) getPeerFromChannel() lookup with O(1) SelectionKey.attachment()
- Coalesce selector wakeup() calls with AtomicBoolean to prevent redundant wakeups