### PR TITLE
added additional logging for EXCEEDS_SIZE_LIMIT for diagnostic purpos…

### DIFF
--- a/src/main/java/org/qortal/arbitrary/ArbitraryDataWriter.java
+++ b/src/main/java/org/qortal/arbitrary/ArbitraryDataWriter.java
@@ -148,6 +148,32 @@ public class ArbitraryDataWriter {
         if (this.service.isValidationRequired()) {
             Service.ValidationResult result = this.service.validate(this.filePath);
             if (result != Service.ValidationResult.OK) {
+                if (result == Service.ValidationResult.EXCEEDS_SIZE_LIMIT) {
+                    long measuredSize = FilesystemUtils.getDirectorySize(this.filePath, true);
+                    long fileCount;
+                    try (Stream<Path> stream = Files.walk(this.filePath)) {
+                        fileCount = stream.filter(Files::isRegularFile).count();
+                    }
+
+                    LOGGER.warn("Service validation size failure for {}: path={}, exists={}, isFile={}, isDirectory={}, fileCount={}, measuredSize={}, maxSize={}",
+                            this.service,
+                            this.filePath,
+                            Files.exists(this.filePath),
+                            Files.isRegularFile(this.filePath),
+                            Files.isDirectory(this.filePath),
+                            fileCount,
+                            measuredSize,
+                            this.service.getMaxSize());
+
+                    throw new DataException(String.format("Validation of %s failed: %s (path=%s, measuredSize=%d, maxSize=%d, fileCount=%d)",
+                            this.service,
+                            result,
+                            this.filePath,
+                            measuredSize,
+                            this.service.getMaxSize(),
+                            fileCount));
+                }
+
                 throw new DataException(String.format("Validation of %s failed: %s", this.service, result.toString()));
             }
         }

--- a/src/main/java/org/qortal/arbitrary/misc/Service.java
+++ b/src/main/java/org/qortal/arbitrary/misc/Service.java
@@ -263,6 +263,10 @@ public enum Service {
         return this.requiresValidation || this.single;
     }
 
+    public Long getMaxSize() {
+        return this.maxSize;
+    }
+
     public boolean isPrivate() {
         return this.isPrivate;
     }


### PR DESCRIPTION
added additional logging for EXCEED_MAX_SIZE to diagnose failures in Q-Mail - Fixed issue related to swagger update that was causing spawn of thousands of threads of `ClassGraph.scan(...)` and eventually causing OOM error on core. Patched ApiService to register a configured Swagger resource instance with explicit JAX-RS classes, which should bypass ClassGraph scanning on openapi.json